### PR TITLE
Fix GCC configuration error.

### DIFF
--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -24,7 +24,10 @@ class ArmElfGcc < Formula
       system '../configure', '--disable-nls', '--target=arm-elf-eabi', '--disable-werror',
                              "--prefix=#{prefix}",
                              "--enable-languages=c",
-                             "--without-headers"
+                             "--without-headers",
+                             "--with-gmp=#{Formula["gmp"].opt_prefix}",
+                             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+                             "--with-mpc=#{Formula["libmpc"].opt_prefix}"
       system 'make all-gcc'
       system 'make install-gcc'
       FileUtils.ln_sf binutils.prefix/"arm-elf-eabi", prefix/"arm-elf-eabi"

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -27,7 +27,10 @@ class I586ElfGcc < Formula
                              '--disable-werror',
                              "--prefix=#{prefix}",
                              "--enable-languages=c",
-                             "--without-headers"
+                             "--without-headers",
+                             "--with-gmp=#{Formula["gmp"].opt_prefix}",
+                             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+                             "--with-mpc=#{Formula["libmpc"].opt_prefix}"
       system 'make all-gcc'
       system 'make install-gcc'
       FileUtils.ln_sf binutils.prefix/"i586-elf", prefix/"i586-elf"

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -25,7 +25,10 @@ class X8664ElfGcc < Formula
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',
                              "--prefix=#{prefix}",
                              "--enable-languages=c",
-                             "--without-headers"
+                             "--without-headers",
+                             "--with-gmp=#{Formula["gmp"].opt_prefix}",
+                             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+                             "--with-mpc=#{Formula["libmpc"].opt_prefix}"
       system 'make all-gcc'
       system 'make install-gcc'
       FileUtils.ln_sf binutils.prefix/"x86_64-elf", prefix/"x86_64-elf"


### PR DESCRIPTION
Apparently GCC builds require explicit locations for these libraries.

After adding this, I was able to build `x86_64-elf-gcc` for sure, and I believe that the `i586` and `arm` ports should work just fine.

Let me know if you have any comments or concerns.