### PR TITLE
Updated arm-elf-binutils.rb to use the actual sha256 of the file

### DIFF
--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -7,10 +7,10 @@ class ArmElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc@5/bin/gcc-5'
-    ENV['CXX'] = '/usr/local/opt/gcc@5/bin/g++-5'
-    ENV['CPP'] = '/usr/local/opt/gcc@5/bin/cpp-5'
-    ENV['LD'] = '/usr/local/opt/gcc@5/bin/gcc-5'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-5'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-5'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-5'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-5'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -3,7 +3,7 @@ require 'formula'
 class ArmElfBinutils < Formula
   homepage 'http://gcc.gnu.org'
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz'
-  sha256 'f10c64e92d9c72ee428df3feaf349c4ecb2493bd'
+  sha256 'f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952'
 
   depends_on 'gcc' => :build
   def install

--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -7,10 +7,10 @@ class ArmElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-5'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-5'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-5'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-5'
+    ENV['CC'] = '/usr/local/opt/gcc@5/bin/gcc-5'
+    ENV['CXX'] = '/usr/local/opt/gcc@5/bin/g++-5'
+    ENV['CPP'] = '/usr/local/opt/gcc@5/bin/cpp-5'
+    ENV['LD'] = '/usr/local/opt/gcc@5/bin/gcc-5'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',


### PR DESCRIPTION
Hi there,
I was unable to install this package because of a checksum failure. Looking at the actual sha256 of the file (by running `shasum -a256 ...`) it looks like the value in this file was incorrect (it was still using the sha1 - the value from `shasum -a1 ...`.